### PR TITLE
Add wait-for utility

### DIFF
--- a/docker-compose-devsecops.yml
+++ b/docker-compose-devsecops.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+services:
+  node:
+    volumes:
+      - /home/training/project/Lab2/:/var/www

--- a/docker-compose-devsecops.yml
+++ b/docker-compose-devsecops.yml
@@ -1,6 +1,0 @@
-version: '3'
-
-services:
-  node:
-    volumes:
-      - /home/training/project/Lab2/:/var/www

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: dockerfile
       dockerfile: Dockerfile-node
-    command: bash -c "cd /var/www && npm install && npm test && npm run coverage && npm start"
+    command: bash -c "/wait-for nodejs_api-mysql:3306 -- npm install && npm test && npm run coverage && npm start"
     container_name: nodejs_api-node
     depends_on:
       - mysql
@@ -15,8 +15,8 @@ services:
       MYSQL_PASSWORD: nodejsapi
       MYSQL_HOST: mysql
     image: nodejs_api-node
-    ports:
-      - "3000:3000"
+    expose:
+      - "3000"
     volumes:
       - ./:/var/www
     working_dir: /var/www
@@ -33,7 +33,7 @@ services:
       MYSQL_PASSWORD: nodejsapi
       MYSQL_ROOT_PASSWORD: password
     image: nodejs_api-mysql
-    ports:
-      - "3306:3306"
+    expose:
+      - "3306"
     volumes:
       - ./data:/var/lib/mysql

--- a/dockerfile/Dockerfile-node
+++ b/dockerfile/Dockerfile-node
@@ -1,1 +1,7 @@
 FROM node:latest
+
+RUN apt-get -q update && apt-get -qy install netcat
+
+#Install the wait-for utility so we can wait for the MYSQL Container to be up
+ADD https://raw.githubusercontent.com/eficode/wait-for/master/wait-for /wait-for
+RUN chmod +x /wait-for


### PR DESCRIPTION
This will make the nodejs container wait for the mysql container to be up and responding on the correct port before launching the npm commands.

This should avoid a race condition where the tests start before the mysql container is up and running